### PR TITLE
Add try/catch block on writeToScreen(message)

### DIFF
--- a/lightbulb/core/utils/webserverhandler.py
+++ b/lightbulb/core/utils/webserverhandler.py
@@ -94,14 +94,18 @@ class WebServerHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 document.getElementById("output").innerHTML = "<img src=# onerror='changed=1'>"+vector;
                 console.log(vector);
                 var el =  document.getElementById("output").childNodes;
-                if (el.length>1){
-                    for (var k in el){
-                      if (el[k] instanceof HTMLElement || el[k].nodeType > 0){
-                        if ("onclick" in el[k]){
-                          el[k].click();
+                if (el.length > 1) {
+                    for (var k in el) {
+                        if (el[k] instanceof HTMLElement || el[k].nodeType > 0) {
+                            if ("onclick" in el[k]) {
+                                try {
+                                    el[k].click();
+                                } catch (error) {
+                                    console.log(error);
+                                }
+                            }
                         }
-                      }
-                  }
+                    }
                 }
                 waitUntil(
                   function () {

--- a/lightbulb/core/utils/webserverhandler.py
+++ b/lightbulb/core/utils/webserverhandler.py
@@ -101,7 +101,7 @@ class WebServerHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                                 try {
                                     el[k].click();
                                 } catch (error) {
-                                    console.log(error);
+                                    //console.log(error);
                                 }
                             }
                         }


### PR DESCRIPTION
The generated vectors sometimes raise an error on the browser because the ```onClick()``` function cannot be called on certain (maybe invalid) elements. This error causes LightBulb to halt testing on the browser.

The issue can be resolved by adding a ```try/catch``` block on ```writeToScreen(message)``` where ```click()``` is called.

```javascript
if (el.length > 1) {
    for (var k in el) {
        if (el[k] instanceof HTMLElement || el[k].nodeType > 0) {
            if ("onclick" in el[k]) {
                try {
                    el[k].click();
                } catch (error) {
                    //console.log(error);
                }
            }
        }
    }
}
```